### PR TITLE
python 3 compatible relative imports

### DIFF
--- a/audiosearch/__init__.py
+++ b/audiosearch/__init__.py
@@ -8,7 +8,7 @@ import os
 import json
 import requests
 
-from client import *
+from .client import *
 
 __version__ = '1.0.0'
 


### PR DESCRIPTION
Python 3 requires clearly designated relative imports (http://stackoverflow.com/a/12173406). `from client import *` fails because it doesn't look locally.